### PR TITLE
Create params instead of extending Wallet.delete()

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -82,14 +82,13 @@ Wallet.prototype.updateMainData = function(p) {
     });
 };
 
-Wallet.prototype.delete = function(p) {
-  var params = _.cloneDeep(p);
-  params = _.extend(params, _.pick(this, [
+Wallet.prototype.delete = function() {
+  var params = _.pick(this, [
     'server',
     'walletId',
     'username',
     'lockVersion'
-  ]));
+  ]);
 
   return protocol.deleteWallet(params);
 };


### PR DESCRIPTION
`Wallet.delete()` does not require any parameters and extending `undefined` returns `undefined`.
